### PR TITLE
Make: Always override GOPATH

### DIFF
--- a/biscuit/GNUmakefile
+++ b/biscuit/GNUmakefile
@@ -8,7 +8,7 @@ ASFLAGS := $(BASEFLAGS) -nostdlib -nostdinc -I$(TOP)
 CFLAGS := $(BASEFLAGS) -ffreestanding -nostdlib -nostdinc -fno-builtin \
 	-mno-red-zone -fno-stack-protector
 CXXFLAGS := $(BASEFLAGS) -ffreestanding -nostdlib -fno-builtin -mno-red-zone
-GOPATH ?= $(shell pwd)
+GOPATH := $(shell pwd)
 # bootloader sources
 ASMS := boot.S
 CS   := bootmain.c main.c chentry.c


### PR DESCRIPTION
When build biscuit, it should always override GOPATH to pwd(biscuit/biscuit/).
Otherwise it won't compile.